### PR TITLE
Update Manifest

### DIFF
--- a/holo/src/main/AndroidManifest.xml
+++ b/holo/src/main/AndroidManifest.xml
@@ -1,9 +1,2 @@
-<manifest
-    package="io.freefair.android.colors.holo"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        tools:ignore="UnusedAttribute">
-    </application>
-</manifest>
+<manifest package="io.freefair.android.colors.holo" />
 

--- a/holo/src/main/AndroidManifest.xml
+++ b/holo/src/main/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <manifest
     package="io.freefair.android.colors.holo"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:allowBackup="true"
-        android:fullBackupContent="true"
         tools:ignore="UnusedAttribute">
     </application>
 </manifest>

--- a/material/src/main/AndroidManifest.xml
+++ b/material/src/main/AndroidManifest.xml
@@ -1,9 +1,2 @@
-<manifest
-    package="io.freefair.android.colors.material"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        tools:ignore="UnusedAttribute">
-    </application>
-</manifest>
+<manifest package="io.freefair.android.colors.material" />
 

--- a/material/src/main/AndroidManifest.xml
+++ b/material/src/main/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <manifest
     package="io.freefair.android.colors.material"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:allowBackup="true"
-        android:fullBackupContent="true"
         tools:ignore="UnusedAttribute">
     </application>
 </manifest>


### PR DESCRIPTION
Otherwise apps using the library get:
```
:app:processDebugManifest
C:\Users\Michael\git\rpicheck\app\src\main\AndroidManifest.xml:20:9-54 Error:
	Attribute application@fullBackupContent value=(@xml/backupscheme) from AndroidManifest.xml:20:9-54
	is also present at [com.github.freefair.android-colors:material:1.1.0] AndroidManifest.xml:14:9-41 value=(true)
	Suggestion: add 'tools:replace="android:fullBackupContent"' to <application> element at AndroidManifest.xml:18:5-103:19 to override
```